### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 Advent of Code solutions for Various years. Currently in Python, but will probably switch to C# as I go back through previous
 years so I can learn that language.
+
+[![Run on Repl.it](https://repl.it/badge/github/samleitermann/AdventofCode)](https://repl.it/github/samleitermann/AdventofCode)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Lightermann/AdventofCode).